### PR TITLE
Fix file/dir creation permissions

### DIFF
--- a/src/code.cloudfoundry.org/envoy-nginx/app/envoy.go
+++ b/src/code.cloudfoundry.org/envoy-nginx/app/envoy.go
@@ -70,12 +70,12 @@ func (a App) GetNginxPath() (path string, err error) {
 func (a App) Run(nginxConfDir, nginxBinPath, sdsIdCreds, sdsC2CCreds, sdsIdValidation string) error {
 	a.SetNginxBin(nginxBinPath)
 
-	err := os.Mkdir(filepath.Join(nginxConfDir, "logs"), os.ModePerm)
+	err := os.Mkdir(filepath.Join(nginxConfDir, "logs"), 0755)
 	if err != nil {
 		return fmt.Errorf("create nginx/logs dir for error.log: %s", err)
 	}
 
-	err = os.Mkdir(filepath.Join(nginxConfDir, "conf"), os.ModePerm)
+	err = os.Mkdir(filepath.Join(nginxConfDir, "conf"), 0755)
 	if err != nil {
 		return fmt.Errorf("create nginx/conf dir for nginx.conf: %s", err)
 	}

--- a/src/code.cloudfoundry.org/envoy-nginx/testhelpers/testhelpers.go
+++ b/src/code.cloudfoundry.org/envoy-nginx/testhelpers/testhelpers.go
@@ -29,7 +29,7 @@ func RotateCert(newfile, sdsfilepath string) error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(tmpPath, contents, 0666)
+	err = os.WriteFile(tmpPath, contents, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Addresses Gosec G306/302/301 errors by fixing file permissions.

On windows only the 0200 and 0400 bits matter, so this doesn't actually change anything to how it functions. However it makes it a lot less scary for tools + people to audit at file permissions.

Backward Compatibility
---------------
Breaking Change? no